### PR TITLE
Prefix API with /api/v1 and switch port to 5050

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -13,7 +13,7 @@ import availabilityRoutes from "./routes/availability.routes"
 
 const app = express()
 const PgStore = connectPgSimple(session)
-const PORT = process.env.PORT ?? 3000
+const PORT = process.env.PORT ?? 5050
 
 // ── Middleware ─────────────────────────────
 app.use(express.json())
@@ -46,39 +46,32 @@ app.use(
 )
 
 // ── Routes ─────────────────────────────────
-app.use("/auth", authRoutes)
-app.use("/employees", employeeRoutes)
-app.use("/schedule", scheduleRoutes)
-app.use("/availability", availabilityRoutes)
+app.use("/api/v1/auth", authRoutes)
+app.use("/api/v1/employees", employeeRoutes)
+app.use("/api/v1/schedule", scheduleRoutes)
+app.use("/api/v1/availability", availabilityRoutes)
 
-
-
-// Optional: add a root route so browser doesn't show Cannot GET /
+// Health check
 app.get("/", (_req, res) => {
   res.json({ message: "Employee Scheduling API is running ✅" })
-})
-
-// Prints all registered routes when server starts
-app.listen(PORT, () => {
-  console.log(`Server running on http://localhost:${PORT}`)
-  console.log("\nRegistered routes:")
-  console.log("  POST   /auth/login")
-  console.log("  POST   /auth/logout")
-  console.log("  GET    /auth/me")
-  console.log("  GET    /employees")
-  console.log("  POST   /employees")
-  console.log("  GET    /employees/:id")
-  console.log("  PUT    /employees/:id")
-  console.log("  DELETE /employees/:id")
-  console.log("  GET    /employees/me")
-  console.log("  GET    /availability/:employeeId")
-  console.log("  PUT    /availability/:employeeId")
-  console.log("  GET    /schedule")
-  console.log("  PUT    /schedule")
-  console.log("  DELETE /schedule/:id")
 })
 
 // ── Start server ───────────────────────────
 app.listen(PORT, () => {
   console.log(`Server running on http://localhost:${PORT}`)
+  console.log("\nRegistered routes:")
+  console.log("  POST   /api/v1/auth/login")
+  console.log("  POST   /api/v1/auth/logout")
+  console.log("  GET    /api/v1/auth/me")
+  console.log("  GET    /api/v1/employees")
+  console.log("  POST   /api/v1/employees")
+  console.log("  GET    /api/v1/employees/:id")
+  console.log("  PUT    /api/v1/employees/:id")
+  console.log("  DELETE /api/v1/employees/:id")
+  console.log("  GET    /api/v1/employees/me")
+  console.log("  GET    /api/v1/availability/:employeeId")
+  console.log("  PUT    /api/v1/availability/:employeeId")
+  console.log("  GET    /api/v1/schedule")
+  console.log("  PUT    /api/v1/schedule")
+  console.log("  DELETE /api/v1/schedule/:id")
 })

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -13,7 +13,7 @@ import availabilityRoutes from "./routes/availability.routes"
 
 const app = express()
 const PgStore = connectPgSimple(session)
-const PORT = process.env.PORT ?? 5050
+const PORT = process.env.BACKEND_PORT ?? process.env.PORT ?? 5050
 
 // ── Middleware ─────────────────────────────
 app.use(express.json())

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+REACT_APP_API_BASE_URL=http://localhost:5050/api/v1

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import './App.css';
 
+const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || "http://localhost:5050/api/v1";
+
 function App() {
   return (
     <div className="App">
@@ -14,7 +16,7 @@ function App() {
 
 // Login
 const login = async () => {
-  const res = await fetch("http://localhost:5050/api/v1/auth/login", {
+  const res = await fetch(`${API_BASE_URL}/auth/login`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     credentials: "include",   // ← always needed for sessions!
@@ -25,7 +27,7 @@ const login = async () => {
 
 // Any protected request
 const getEmployees = async () => {
-  const res = await fetch("http://localhost:5050/api/v1/employees", {
+  const res = await fetch(`${API_BASE_URL}/employees`, {
     credentials: "include"    // ← sends cookie automatically
   })
   const data = await res.json()
@@ -33,7 +35,7 @@ const getEmployees = async () => {
 
 // Logout
 const logout = async () => {
-  await fetch("http://localhost:5050/api/v1/auth/logout", {
+  await fetch(`${API_BASE_URL}/auth/logout`, {
     method: "POST",
     credentials: "include"
   })

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,7 +14,7 @@ function App() {
 
 // Login
 const login = async () => {
-  const res = await fetch("http://localhost:3000/auth/login", {
+  const res = await fetch("http://localhost:5050/api/v1/auth/login", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     credentials: "include",   // ← always needed for sessions!
@@ -25,7 +25,7 @@ const login = async () => {
 
 // Any protected request
 const getEmployees = async () => {
-  const res = await fetch("http://localhost:3000/employees", {
+  const res = await fetch("http://localhost:5050/api/v1/employees", {
     credentials: "include"    // ← sends cookie automatically
   })
   const data = await res.json()
@@ -33,7 +33,7 @@ const getEmployees = async () => {
 
 // Logout
 const logout = async () => {
-  await fetch("http://localhost:3000/auth/logout", {
+  await fetch("http://localhost:5050/api/v1/auth/logout", {
     method: "POST",
     credentials: "include"
   })


### PR DESCRIPTION
- Introduce API versioning and align client/server ports: backend default PORT changed from 3000 to 5050.

- All routes are now mounted under /api/v1 (auth, employees, schedule, availability), and the root route comment was clarified to a health check. 

- Server startup now logs the updated /api/v1 endpoints. Corresponding frontend fetch calls were updated to use http://localhost:5050/api/v1/... for login, logout and employees requests so the client matches the new API paths and port.