### PR TITLE
Allow employees to assign their own schedules

### DIFF
--- a/backend/src/controllers/availability.controller.ts
+++ b/backend/src/controllers/availability.controller.ts
@@ -26,7 +26,7 @@ export async function fetchAvailability(req: AuthRequest, res: Response, next: N
 
 export async function setAvailability(req: AuthRequest, res: Response, next: NextFunction): Promise<void> {
   try {
-    const employeeId = parseInt(req.params.employeeId);
+    const employeeId = parseInt(req.params.employeeId as string);
     if (isNaN(employeeId)) {
       res.status(400).json({ error: 'Invalid employee ID' });
       return;

--- a/backend/src/controllers/schedule.controller.ts
+++ b/backend/src/controllers/schedule.controller.ts
@@ -16,7 +16,7 @@ export async function fetchSchedule(req: AuthRequest, res: Response, next: NextF
 }
  
 
-//PUT /schedule – employer assigns employees to shifts-
+//PUT /schedule – employer or employee assigns shifts-
 export async function assignSchedule(req: AuthRequest, res: Response, next: NextFunction): Promise<void> {
   try {
     const input = UpdateScheduleSchema.parse(req.body);

--- a/backend/src/controllers/schedule.controller.ts
+++ b/backend/src/controllers/schedule.controller.ts
@@ -20,6 +20,16 @@ export async function fetchSchedule(req: AuthRequest, res: Response, next: NextF
 export async function assignSchedule(req: AuthRequest, res: Response, next: NextFunction): Promise<void> {
   try {
     const input = UpdateScheduleSchema.parse(req.body);
+
+    // If logged in as EMPLOYEE, they can only add schedule for themselves
+    if (req.user?.role === 'EMPLOYEE') {
+      const isOwnOnly = input.entries.every(entry => entry.employeeId === req.user?.employeeId)
+      if (!isOwnOnly) {
+        res.status(403).json({ error: 'You can only add schedule entries for yourself' })
+        return
+      }
+    }
+
     const results = await updateSchedule(input);
     res.status(200).json({ message: 'Schedule updated', count: results.length, results });
   } catch (err) {

--- a/backend/src/controllers/schedule.controller.ts
+++ b/backend/src/controllers/schedule.controller.ts
@@ -23,10 +23,16 @@ export async function assignSchedule(req: AuthRequest, res: Response, next: Next
 
     // If logged in as EMPLOYEE, they can only add schedule for themselves
     if (req.user?.role === 'EMPLOYEE') {
-      const isOwnOnly = input.entries.every(entry => entry.employeeId === req.user?.employeeId)
+      const employeeId = req.user.employeeId;
+      if (employeeId === undefined) {
+        res.status(403).json({ error: 'Employee session is missing employee ID' });
+        return;
+      }
+
+      const isOwnOnly = input.entries.every(entry => entry.employeeId === employeeId);
       if (!isOwnOnly) {
-        res.status(403).json({ error: 'You can only add schedule entries for yourself' })
-        return
+        res.status(403).json({ error: 'You can only add schedule entries for yourself' });
+        return;
       }
     }
 

--- a/backend/src/routes/schedule.routes.ts
+++ b/backend/src/routes/schedule.routes.ts
@@ -8,8 +8,8 @@ router.use(authenticate);
 // GET /schedule — both employer and employee
 router.get('/', fetchSchedule);
 
-// PUT /schedule — employer only
-router.put('/', requireEmployer, assignSchedule);
+// PUT /schedule — both employer and employee
+router.put('/', assignSchedule);
 
 // DELETE /schedule/:id — employer only
 router.delete('/:id', requireEmployer, removeScheduleEntry);

--- a/backend/src/schema/index.ts
+++ b/backend/src/schema/index.ts
@@ -1,9 +1,4 @@
-import { z } from "zod"
-
-// ─────────────────────────────────────────
-// Install zod if not already installed:
-// npm install zod
-// ─────────────────────────────────────────
+import { z } from "zod";
 
 // ── Day of week ───────────────────────────
 export const DayOfWeekSchema = z.enum([


### PR DESCRIPTION
Add a server-side check in assignSchedule so users with role EMPLOYEE can only add schedule entries for their own employeeId (responds 403 if not). Update routes to allow PUT /schedule for employees as well by removing the requireEmployer middleware. Also remove extraneous zod installation comment and tidy import formatting in schema index.