### PR TITLE
Updated logic to filter schedule based upon the loggedin Role

### DIFF
--- a/backend/src/controllers/schedule.controller.ts
+++ b/backend/src/controllers/schedule.controller.ts
@@ -8,7 +8,11 @@ import { getSchedule, updateSchedule, deleteScheduleEntry } from '../services/sc
 export async function fetchSchedule(req: AuthRequest, res: Response, next: NextFunction): Promise<void> {
   try {
     const { startDate, endDate } = req.query as { startDate?: string; endDate?: string };
-    const schedule = await getSchedule(startDate, endDate);
+
+    // EMPLOYEE sees only their own schedule, EMPLOYER sees all schedules.
+    const employeeId = req.user?.role === 'EMPLOYEE' ? req.user.employeeId : undefined
+
+    const schedule = await getSchedule(startDate, endDate, employeeId);
     res.status(200).json(schedule);
   } catch (err) {
     next(err);

--- a/backend/src/controllers/schedule.controller.ts
+++ b/backend/src/controllers/schedule.controller.ts
@@ -10,7 +10,14 @@ export async function fetchSchedule(req: AuthRequest, res: Response, next: NextF
     const { startDate, endDate } = req.query as { startDate?: string; endDate?: string };
 
     // EMPLOYEE sees only their own schedule, EMPLOYER sees all schedules.
-    const employeeId = req.user?.role === 'EMPLOYEE' ? req.user.employeeId : undefined
+    let employeeId: number | undefined;
+    if (req.user?.role === 'EMPLOYEE') {
+      employeeId = req.user.employeeId;
+      if (employeeId === undefined) {
+        res.status(403).json({ error: 'Employee session is missing employee ID' });
+        return;
+      }
+    }
 
     const schedule = await getSchedule(startDate, endDate, employeeId);
     res.status(200).json(schedule);

--- a/backend/src/services/schedule.service.ts
+++ b/backend/src/services/schedule.service.ts
@@ -13,7 +13,7 @@ import { ShiftType } from '@prisma/client'
 // Returns all schedule entries within a date range.
 // If no dates provided, defaults to the current week (Mon–Sun).
 // ─────────────────────────────────────────
-export async function getSchedule(startDate?: string, endDate?: string) {
+export async function getSchedule(startDate?: string, endDate?: string, employeeId?: number) {
   // Default to current week if no dates given
   const today = new Date()
   const dayOfWeek = today.getDay() // 0 = Sun, 1 = Mon ...
@@ -30,7 +30,9 @@ export async function getSchedule(startDate?: string, endDate?: string) {
 
   return prisma.scheduleEntry.findMany({
     where: {
-      date: { gte: from, lte: to }
+      date: { gte: from, lte: to },
+      // If employeeId provided, filter to that employee only
+      ...(employeeId !== undefined && { employeeId })
     },
     include: {
       employee: {


### PR DESCRIPTION
This pull request updates the schedule fetching logic to support role-based access, allowing employees to see only their own schedules while employers can see all schedules. The main changes are focused on filtering schedule data based on the user's role and employee ID.
